### PR TITLE
Investigate Next.js routes manifest error documentation

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,4 @@
 {
-  "buildCommand": "npm run build",
-  "devCommand": "npm run dev",
-  "installCommand": "npm install",
   "framework": "nextjs",
   "build": {
     "env": {


### PR DESCRIPTION
Elimina comandos explícitos (buildCommand, devCommand, installCommand) para permitir que la integración nativa de Next.js en Vercel detecte correctamente el directorio de salida .next/ donde se genera el routes-manifest.json.