### PR TITLE
Fix 404 error

### DIFF
--- a/lib/tmdb.js
+++ b/lib/tmdb.js
@@ -1,0 +1,55 @@
+import axios from 'axios'
+import qs from 'qs'
+
+const TMDB_BASE_URL = 'https://api.themoviedb.org/3'
+
+const tmdbClient = axios.create({
+  baseURL: TMDB_BASE_URL,
+  headers: {
+    'content-type': 'application/json;charset=utf-8',
+  },
+})
+
+// Add auth header dynamically to ensure env var is read at runtime
+tmdbClient.interceptors.request.use((config) => {
+  config.headers.Authorization = `Bearer ${process.env.TMDB_API_TOKEN}`
+  return config
+})
+
+export async function searchMovies(query, page = 1) {
+  const pageNum = parseInt(page, 10)
+  const validPage = pageNum < 1 || pageNum > 1000 ? 1 : pageNum
+
+  const response = await tmdbClient.get('/search/movie', {
+    params: {
+      query,
+      page: validPage,
+    },
+    paramsSerializer: params => qs.stringify(params),
+  })
+
+  return response.data
+}
+
+export async function getTrendingMovies(page = 1) {
+  const pageNum = parseInt(page, 10)
+  const validPage = pageNum < 1 || pageNum > 1000 ? 1 : pageNum
+
+  const response = await tmdbClient.get('/trending/movie/week', {
+    params: {
+      page: validPage,
+    },
+  })
+
+  return response.data
+}
+
+export async function getMovieById(id) {
+  const response = await tmdbClient.get(`/movie/${id}`)
+  return response.data
+}
+
+export async function getMovieCast(id) {
+  const response = await tmdbClient.get(`/movie/${id}/credits`)
+  return response.data
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,9 @@
         "@types/react-dom": "^19.2.3",
         "eslint": "^9.14.0",
         "eslint-config-next": "^16.0.3"
+      },
+      "engines": {
+        "node": "22.x"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/pages/api/movies/[id].js
+++ b/pages/api/movies/[id].js
@@ -1,4 +1,4 @@
-import axios from 'axios'
+import { getMovieById } from '../../../lib/tmdb'
 
 export default async function handler(req, res) {
   if (req.method !== 'GET') {
@@ -12,16 +12,8 @@ export default async function handler(req, res) {
   }
 
   try {
-    const response = await axios({
-      method: 'GET',
-      url: `https://api.themoviedb.org/3/movie/${id}`,
-      headers: {
-        'content-type': 'application/json;charset=utf-8',
-        Authorization: `Bearer ${process.env.TMDB_API_TOKEN}`,
-      },
-    })
-
-    res.status(200).json(response.data)
+    const data = await getMovieById(id)
+    res.status(200).json(data)
   } catch (error) {
     console.error('Error fetching movie:', error.message)
     res.status(error.response?.status || 500).json({

--- a/pages/api/movies/[id]/cast.js
+++ b/pages/api/movies/[id]/cast.js
@@ -1,4 +1,4 @@
-import axios from 'axios'
+import { getMovieCast } from '../../../../lib/tmdb'
 
 export default async function handler(req, res) {
   if (req.method !== 'GET') {
@@ -12,16 +12,8 @@ export default async function handler(req, res) {
   }
 
   try {
-    const response = await axios({
-      method: 'GET',
-      url: `https://api.themoviedb.org/3/movie/${id}/credits`,
-      headers: {
-        'content-type': 'application/json;charset=utf-8',
-        Authorization: `Bearer ${process.env.TMDB_API_TOKEN}`,
-      },
-    })
-
-    res.status(200).json(response.data)
+    const data = await getMovieCast(id)
+    res.status(200).json(data)
   } catch (error) {
     console.error('Error fetching cast:', error.message)
     res.status(error.response?.status || 500).json({

--- a/pages/api/movies/trending.js
+++ b/pages/api/movies/trending.js
@@ -1,4 +1,4 @@
-import axios from 'axios'
+import { getTrendingMovies } from '../../../lib/tmdb'
 
 export default async function handler(req, res) {
   if (req.method !== 'GET') {
@@ -6,23 +6,10 @@ export default async function handler(req, res) {
   }
 
   const { page = 1 } = req.query
-  const pageNum = parseInt(page, 10)
-  const validPage = pageNum < 1 || pageNum > 1000 ? 1 : pageNum
 
   try {
-    const response = await axios({
-      method: 'GET',
-      url: 'https://api.themoviedb.org/3/trending/movie/week',
-      headers: {
-        'content-type': 'application/json;charset=utf-8',
-        Authorization: `Bearer ${process.env.TMDB_API_TOKEN}`,
-      },
-      params: {
-        page: validPage,
-      },
-    })
-
-    res.status(200).json(response.data)
+    const data = await getTrendingMovies(page)
+    res.status(200).json(data)
   } catch (error) {
     console.error('Error fetching trending movies:', error.message)
     res.status(error.response?.status || 500).json({

--- a/pages/api/search.js
+++ b/pages/api/search.js
@@ -1,5 +1,4 @@
-import axios from 'axios'
-import qs from 'qs'
+import { searchMovies } from '../../lib/tmdb'
 
 export default async function handler(req, res) {
   if (req.method !== 'GET') {
@@ -12,25 +11,9 @@ export default async function handler(req, res) {
     return res.status(400).json({ error: 'Search query is required' })
   }
 
-  const pageNum = parseInt(page, 10)
-  const validPage = pageNum < 1 || pageNum > 1000 ? 1 : pageNum
-
   try {
-    const response = await axios({
-      method: 'GET',
-      url: 'https://api.themoviedb.org/3/search/movie',
-      headers: {
-        'content-type': 'application/json;charset=utf-8',
-        Authorization: `Bearer ${process.env.TMDB_API_TOKEN}`,
-      },
-      params: {
-        query,
-        page: validPage,
-      },
-      paramsSerializer: params => qs.stringify(params),
-    })
-
-    res.status(200).json(response.data)
+    const data = await searchMovies(query, page)
+    res.status(200).json(data)
   } catch (error) {
     console.error('Error searching movies:', error.message)
     res.status(error.response?.status || 500).json({

--- a/pages/movies/[id].js
+++ b/pages/movies/[id].js
@@ -1,10 +1,10 @@
 import { useRouter } from 'next/router'
 import Head from 'next/head'
 import Image from 'next/image'
-import axios from 'axios'
 import styled from 'styled-components'
 import Loading from '../../components/Loading'
 import Cast from '../../components/Cast'
+import { getMovieById } from '../../lib/tmdb'
 
 const ModalContainer = styled.div`
   margin: 0;
@@ -259,12 +259,11 @@ export async function getServerSideProps(context) {
   const { id } = context.params
 
   try {
-    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `http://localhost:3000`
-    const response = await axios.get(`${baseUrl}/api/movies/${id}`)
+    const data = await getMovieById(id)
 
     return {
       props: {
-        data: response.data,
+        data,
         error: null,
       },
     }

--- a/pages/movies/index.js
+++ b/pages/movies/index.js
@@ -1,10 +1,10 @@
 import Head from 'next/head'
 import Link from 'next/link'
 import Image from 'next/image'
-import axios from 'axios'
 import styled from 'styled-components'
 import Loading from '../../components/Loading'
 import Pagination from '../../components/Pagination'
+import { getTrendingMovies } from '../../lib/tmdb'
 
 const TrendingTitle = styled.h1`
   margin: 0;
@@ -192,14 +192,11 @@ export async function getServerSideProps(context) {
   const { page = 1 } = context.query
 
   try {
-    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `http://localhost:3000`
-    const response = await axios.get(`${baseUrl}/api/movies/trending`, {
-      params: { page },
-    })
+    const data = await getTrendingMovies(page)
 
     return {
       props: {
-        data: response.data,
+        data,
         error: null,
       },
     }

--- a/pages/search.js
+++ b/pages/search.js
@@ -1,12 +1,12 @@
 import { useState } from 'react'
 import { useRouter } from 'next/router'
 import Head from 'next/head'
-import axios from 'axios'
 import styled from 'styled-components'
 import SearchButton from '../components/SearchButton'
 import Loading from '../components/Loading'
 import MovieCard from '../components/MovieCard'
 import Pagination from '../components/Pagination'
+import { searchMovies } from '../lib/tmdb'
 
 const SearchContainer = styled.div`
   position: relative;
@@ -197,14 +197,11 @@ export async function getServerSideProps(context) {
   }
 
   try {
-    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `http://localhost:3000`
-    const response = await axios.get(`${baseUrl}/api/search`, {
-      params: { query, page },
-    })
+    const data = await searchMovies(query, page)
 
     return {
       props: {
-        data: response.data,
+        data,
         error: null,
         searchQuery: query,
       },


### PR DESCRIPTION
The 404 error was caused by pages making HTTP requests to their own API routes during SSR, which fails on Vercel. This refactors the code to:

- Create shared lib/tmdb.js service with direct TMDB API calls
- Update getServerSideProps in pages to import and use service directly
- Refactor API routes to use the same shared service for consistency

This eliminates the self-referential HTTP requests that were causing the NOT_FOUND error on Vercel deployments.