### PR TITLE
Fix mobile layout and enlarge cast text

### DIFF
--- a/components/MoviesGrid.jsx
+++ b/components/MoviesGrid.jsx
@@ -8,7 +8,7 @@ const Grid = styled.div`
   padding: 20px;
   width: 100%;
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(1, 1fr);
   gap: 16px;
 
   @media (min-width: 640px) {

--- a/components/Person.jsx
+++ b/components/Person.jsx
@@ -31,11 +31,11 @@ const P = styled.span`
   display: block;
   width: 90px;
   text-align: center;
-  font-size: 12px;
+  font-size: 14px;
   line-height: 1.2;
   @media screen and (min-width: 1200px) {
     width: 110px;
-    font-size: 14px;
+    font-size: 16px;
   }
 `
 


### PR DESCRIPTION
- Cambiar grid mobile de 2 columnas a 1 columna para mejor visualización
- Aumentar font-size del cast de 12px a 14px en mobile y de 14px a 16px en desktop