### PR TITLE
Fix cast styling and mobile layout issues

### DIFF
--- a/components/Cast.jsx
+++ b/components/Cast.jsx
@@ -8,11 +8,18 @@ import { CastSkeleton } from './Skeleton'
 const Container = styled.div`
   margin-top: 40px;
   margin-bottom: 22px;
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: flex-start;
-  align-items: center;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
+  gap: 8px 4px;
+  align-items: start;
+  @media screen and (max-width: 600px) {
+    grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+    gap: 12px 8px;
+  }
+  @media screen and (min-width: 1200px) {
+    grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+    gap: 12px 8px;
+  }
 `
 
 export default function Cast({ movieId }) {

--- a/components/Person.jsx
+++ b/components/Person.jsx
@@ -4,11 +4,8 @@ import Image from 'next/image'
 import styled from 'styled-components'
 
 const Content = styled.div`
-  margin-right: 8px;
-  margin-bottom: 15px;
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
 `
 
@@ -27,29 +24,29 @@ const Container = styled.div`
 `
 
 const P = styled.span`
-  margin-top: 11px;
+  margin-top: 8px;
   display: block;
-  width: 90px;
+  width: 100%;
   text-align: center;
-  font-size: 14px;
-  line-height: 1.2;
+  font-size: 12px;
+  line-height: 1.3;
+  word-break: break-word;
   @media screen and (min-width: 1200px) {
-    width: 110px;
-    font-size: 16px;
+    font-size: 14px;
   }
 `
 
 const Character = styled.span`
   display: block;
-  width: 90px;
+  width: 100%;
   text-align: center;
-  font-size: 12px;
+  font-size: 10px;
   line-height: 1.2;
   color: #888;
-  margin-top: 4px;
+  margin-top: 2px;
+  word-break: break-word;
   @media screen and (min-width: 1200px) {
-    width: 110px;
-    font-size: 13px;
+    font-size: 11px;
   }
 `
 

--- a/components/Skeleton.jsx
+++ b/components/Skeleton.jsx
@@ -105,11 +105,8 @@ export function MovieCardSkeleton() {
 
 // Cast Person Skeleton Component
 const PersonSkeletonContainer = styled.div`
-  margin-right: 8px;
-  margin-bottom: 15px;
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
 `
 
@@ -117,7 +114,8 @@ export function PersonSkeleton() {
   return (
     <PersonSkeletonContainer>
       <AvatarSkeleton />
-      <TextSkeleton $width="70px" $height="12px" $mb="0" style={{ marginTop: '11px' }} />
+      <TextSkeleton $width="70%" $height="10px" $mb="0" style={{ marginTop: '8px' }} />
+      <TextSkeleton $width="50%" $height="8px" $mb="0" style={{ marginTop: '4px' }} />
     </PersonSkeletonContainer>
   )
 }
@@ -160,13 +158,17 @@ export function MoviesGridSkeleton({ count = 10 }) {
 const CastSkeletonContainer = styled.div`
   margin-top: 40px;
   margin-bottom: 22px;
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: center;
-
-  @media screen and (min-width: 600px) {
-    justify-content: flex-start;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
+  gap: 8px 4px;
+  align-items: start;
+  @media screen and (max-width: 600px) {
+    grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+    gap: 12px 8px;
+  }
+  @media screen and (min-width: 1200px) {
+    grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+    gap: 12px 8px;
   }
 `
 


### PR DESCRIPTION
- Cambiar layout de flexbox a CSS Grid para distribución uniforme
- Alinear todos los items al inicio para evitar desalineación
- Agregar word-break para nombres/personajes largos
- Distribuir items en toda la pantalla en mobile
- Actualizar skeletons para coincidir con nuevo layout