### PR TITLE
security: add .npmrc with ignore-scripts=true

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
## Summary
- Adds project-level `.npmrc` setting `ignore-scripts=true`
- Blocks npm from executing `preinstall`/`install`/`postinstall` scripts from dependencies
- Mitigates supply-chain attacks (e.g. Sept 2025 chalk/debug compromise, Shai-Hulud worm)

## Why
Industry-recommended defense after a wave of npm supply-chain attacks. Committing this to the repo means every clone, CI run, and Vercel deploy inherits the protection automatically — security-as-code.

## Impact on this project
Current deps (Next.js, React, axios, styled-components, qs) do not require postinstall scripts, so the build is unaffected. If a future dependency legitimately needs a build step (e.g. native binaries like `sharp`), run `npm rebuild <pkg>` explicitly after reviewing what the script does.

## Test plan
- [ ] `rm -rf node_modules && npm install` completes successfully
- [ ] `npm run build` succeeds
- [ ] `npm run dev` starts the app
- [ ] Vercel preview deploy builds green

🤖 Generated with [Claude Code](https://claude.com/claude-code)