### PR TITLE
feat(person): actor page with filmography sorted newest→oldest

### DIFF
--- a/components/Cast.jsx
+++ b/components/Cast.jsx
@@ -40,6 +40,7 @@ export default function Cast({ movieId }) {
       {cast.cast.slice(0, 12).map((actor, index) => (
         <Person
           key={index}
+          id={actor.id}
           avatar={actor.profile_path}
           name={actor.name}
           character={actor.character}

--- a/components/Person.jsx
+++ b/components/Person.jsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Image from 'next/image'
+import Link from 'next/link'
 import styled from 'styled-components'
 import { useState } from 'react'
 
@@ -39,10 +40,20 @@ const Container = styled.div`
   border: 1px solid #101010;
   border-radius: 50%;
   overflow: hidden;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+  &:hover {
+    transform: scale(1.05);
+  }
   @media screen and (min-width: 1200px) {
     width: 100px;
     height: 100px;
   }
+`
+
+const AvatarLink = styled(Link)`
+  display: block;
+  line-height: 0;
 `
 
 const P = styled.span`
@@ -77,7 +88,7 @@ const Character = styled.span`
   }
 `
 
-export default function Person({ avatar, name, character }) {
+export default function Person({ id, avatar, name, character }) {
   const [showTooltip, setShowTooltip] = useState(false)
 
   const copyToClipboard = (text) => {
@@ -88,21 +99,29 @@ export default function Person({ avatar, name, character }) {
     }
   }
 
+  const avatarContent = (
+    <Container>
+      {avatar ? (
+        <Image
+          src={`https://image.tmdb.org/t/p/w500/${avatar}`}
+          alt={name || 'Actor'}
+          fill
+          sizes="(max-width: 1200px) 80px, 100px"
+          style={{ objectFit: 'cover' }}
+        />
+      ) : (
+        <div style={{ width: '100%', background: '#333' }} />
+      )}
+    </Container>
+  )
+
   return (
     <Content>
-      <Container onClick={() => copyToClipboard(name)}>
-        {avatar ? (
-          <Image
-            src={`https://image.tmdb.org/t/p/w500/${avatar}`}
-            alt={name || 'Actor'}
-            fill
-            sizes="(max-width: 1200px) 80px, 100px"
-            style={{ objectFit: 'cover' }}
-          />
-        ) : (
-          <div style={{ width: '100%', background: '#333' }} />
-        )}
-      </Container>
+      {id ? (
+        <AvatarLink href={`/person/${id}`}>{avatarContent}</AvatarLink>
+      ) : (
+        avatarContent
+      )}
       <P onClick={() => copyToClipboard(name)}>{name}</P>
       {character && <Character onClick={() => copyToClipboard(character)}>({character})</Character>}
       {showTooltip && <Tooltip>Copied!</Tooltip>}

--- a/src/app/api/person/[id]/credits/route.ts
+++ b/src/app/api/person/[id]/credits/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getPersonMovieCredits } from '@/lib/tmdb'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+
+  if (!id) {
+    return NextResponse.json(
+      { error: 'Person ID is required' },
+      { status: 400 }
+    )
+  }
+
+  try {
+    const data = await getPersonMovieCredits(id)
+    return NextResponse.json(data)
+  } catch (error) {
+    console.error('Error fetching person credits:', error)
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+    return NextResponse.json(
+      { error: 'Failed to fetch person credits', message: errorMessage },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/person/[id]/route.ts
+++ b/src/app/api/person/[id]/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getPerson } from '@/lib/tmdb'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+
+  if (!id) {
+    return NextResponse.json(
+      { error: 'Person ID is required' },
+      { status: 400 }
+    )
+  }
+
+  try {
+    const data = await getPerson(id)
+    return NextResponse.json(data)
+  } catch (error) {
+    console.error('Error fetching person:', error)
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+    return NextResponse.json(
+      { error: 'Failed to fetch person', message: errorMessage },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -68,7 +68,7 @@ const Description = styled.div`
 `
 
 const Title = styled.h2`
-  cursor: pointer;
+  cursor: text;
   position: relative;
   display: inline-block;
 `

--- a/src/app/person/[id]/page.tsx
+++ b/src/app/person/[id]/page.tsx
@@ -1,0 +1,307 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import Image from 'next/image'
+import styled from 'styled-components'
+import useSWR from 'swr'
+import Loading from '../../../../components/Loading'
+import MoviesGrid from '../../../../components/MoviesGrid'
+import { MoviesGridSkeleton } from '../../../../components/Skeleton'
+
+const PAGE_SIZE = 20
+
+const Container = styled.div`
+  margin: 0;
+  padding: 0 20px 50px;
+  width: 100%;
+  max-width: 1400px;
+  margin: 0 auto;
+  min-height: calc(100vh - 50px);
+`
+
+const Header = styled.div`
+  margin-top: 30px;
+  padding: 20px;
+  display: flex;
+  flex-direction: row;
+  gap: 24px;
+  align-items: flex-start;
+  background-color: #050505d2;
+  border-radius: 10px;
+  color: #fff;
+  position: relative;
+  @media screen and (max-width: 600px) {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+`
+
+const Avatar = styled.div`
+  position: relative;
+  width: 180px;
+  height: 180px;
+  border-radius: 50%;
+  overflow: hidden;
+  flex-shrink: 0;
+  border: 1px solid #101010;
+  @media screen and (min-width: 1200px) {
+    width: 220px;
+    height: 220px;
+  }
+`
+
+const PlaceholderAvatar = styled.div`
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, #1a1a1a 0%, #2d2d2d 100%);
+`
+
+const Info = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+`
+
+const Name = styled.h1`
+  margin: 0;
+  font-family: 'Raleway', sans-serif;
+  font-size: 32px;
+  font-weight: 900;
+  letter-spacing: 1px;
+  @media screen and (min-width: 1200px) {
+    font-size: 40px;
+  }
+`
+
+const Department = styled.span`
+  font-family: 'Raleway', sans-serif;
+  font-size: 13px;
+  color: #ffaf7b;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+`
+
+const Bio = styled.p`
+  margin: 8px 0 0;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  font-size: 14px;
+  line-height: 1.6;
+  color: #ccc;
+  display: -webkit-box;
+  -webkit-line-clamp: 6;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+`
+
+const Close = styled.div`
+  position: absolute;
+  right: 20px;
+  top: 10px;
+  width: 32px;
+  height: 32px;
+  transition: all 0.3s;
+  cursor: pointer;
+  z-index: 10;
+  :hover {
+    transform: rotateZ(90deg);
+    transition: all 0.6s;
+  }
+  ::before,
+  ::after {
+    content: '';
+    position: absolute;
+    top: 15px;
+    right: 0;
+    width: 25px;
+    border: 1px solid;
+    border-image-source: linear-gradient(
+      to bottom,
+      #ffaf7b,
+      rgb(204, 215, 109),
+      rgb(97, 113, 28)
+    );
+    border-image-slice: 1;
+    transition: 0.3s;
+  }
+  ::before {
+    transform: rotate(45deg);
+  }
+  ::after {
+    transform: rotate(-45deg);
+  }
+`
+
+const SectionTitle = styled.h2`
+  margin: 40px 0 10px;
+  padding: 0 10px;
+  font-family: 'Raleway', sans-serif;
+  font-size: 24px;
+  font-weight: 700;
+  color: #fff;
+  letter-spacing: 1px;
+`
+
+const LoadingMore = styled.div`
+  width: 100%;
+  padding: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`
+
+const EndMessage = styled.p`
+  font-family: 'Raleway', sans-serif;
+  font-size: 14px;
+  font-weight: 300;
+  color: #888;
+  text-align: center;
+  padding: 40px;
+  letter-spacing: 1px;
+`
+
+interface PersonData {
+  id: number
+  name: string
+  biography: string
+  profile_path: string | null
+  known_for_department: string
+}
+
+interface CreditMovie {
+  id: number
+  title: string
+  poster_path: string | null
+  release_date: string
+  vote_average: number
+}
+
+interface CreditsData {
+  cast: CreditMovie[]
+}
+
+export default function Person() {
+  const router = useRouter()
+  const params = useParams()
+  const id = params.id as string
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE)
+  const loadMoreRef = useRef<HTMLDivElement | null>(null)
+
+  const { data: person, error: personError, isLoading: personLoading } = useSWR<PersonData>(
+    id ? `/api/person/${id}` : null,
+    { revalidateOnFocus: false, dedupingInterval: 300000 }
+  )
+
+  const { data: credits, error: creditsError, isLoading: creditsLoading } = useSWR<CreditsData>(
+    id ? `/api/person/${id}/credits` : null,
+    { revalidateOnFocus: false, dedupingInterval: 300000 }
+  )
+
+  // De-duplicate (an actor can appear twice if credited in multiple roles)
+  // and sort newest → oldest. Movies without a release_date go to the end.
+  const sortedMovies = useMemo(() => {
+    if (!credits?.cast) return []
+    const seen = new Set<number>()
+    const unique = credits.cast.filter((m) => {
+      if (seen.has(m.id)) return false
+      seen.add(m.id)
+      return true
+    })
+    return unique.sort((a, b) => {
+      if (!a.release_date && !b.release_date) return 0
+      if (!a.release_date) return 1
+      if (!b.release_date) return -1
+      return b.release_date.localeCompare(a.release_date)
+    })
+  }, [credits])
+
+  const visibleMovies = sortedMovies.slice(0, visibleCount)
+  const hasMore = visibleCount < sortedMovies.length
+
+  useEffect(() => {
+    if (!loadMoreRef.current || !hasMore) return
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          setVisibleCount((c) => c + PAGE_SIZE)
+        }
+      },
+      { threshold: 0.1 }
+    )
+    observer.observe(loadMoreRef.current)
+    return () => observer.disconnect()
+  }, [hasMore])
+
+  if (personError || creditsError) {
+    return (
+      <Container>
+        <h3 style={{ color: '#FFF', marginTop: '50px' }}>
+          Error: {(personError || creditsError)?.message}
+        </h3>
+      </Container>
+    )
+  }
+
+  if (personLoading || !person) {
+    return (
+      <Container>
+        <MoviesGridSkeleton count={10} />
+      </Container>
+    )
+  }
+
+  return (
+    <Container>
+      <Header>
+        <Close onClick={() => router.back()} />
+        <Avatar>
+          {person.profile_path ? (
+            <Image
+              src={`https://image.tmdb.org/t/p/w500/${person.profile_path}`}
+              alt={person.name}
+              fill
+              sizes="(max-width: 1200px) 180px, 220px"
+              style={{ objectFit: 'cover' }}
+              priority
+            />
+          ) : (
+            <PlaceholderAvatar />
+          )}
+        </Avatar>
+        <Info>
+          <Name>{person.name}</Name>
+          {person.known_for_department && (
+            <Department>{person.known_for_department}</Department>
+          )}
+          {person.biography && <Bio>{person.biography}</Bio>}
+        </Info>
+      </Header>
+
+      <SectionTitle>
+        Filmography {sortedMovies.length > 0 && `(${sortedMovies.length})`}
+      </SectionTitle>
+
+      {creditsLoading ? (
+        <MoviesGridSkeleton count={10} />
+      ) : (
+        <>
+          <MoviesGrid movies={visibleMovies} />
+          {hasMore && (
+            <LoadingMore ref={loadMoreRef}>
+              <Loading />
+            </LoadingMore>
+          )}
+          {!hasMore && visibleMovies.length > 0 && (
+            <EndMessage>no more results</EndMessage>
+          )}
+          {!creditsLoading && sortedMovies.length === 0 && (
+            <EndMessage>no movies found for this person</EndMessage>
+          )}
+        </>
+      )}
+    </Container>
+  )
+}

--- a/src/lib/tmdb.ts
+++ b/src/lib/tmdb.ts
@@ -53,3 +53,13 @@ export async function getMovieCast(id: string | number) {
   const response = await tmdbClient.get(`/movie/${id}/credits`)
   return response.data
 }
+
+export async function getPerson(id: string | number) {
+  const response = await tmdbClient.get(`/person/${id}`)
+  return response.data
+}
+
+export async function getPersonMovieCredits(id: string | number) {
+  const response = await tmdbClient.get(`/person/${id}/movie_credits`)
+  return response.data
+}


### PR DESCRIPTION
## Summary
- Click on an actor's avatar in any movie's cast → navigate to `/person/[id]` with their full TMDb filmography
- Filmography sorted **newest → oldest** by `release_date` (movies without a release_date go to the end)
- Progressive client-side render (20 at a time via `IntersectionObserver`) so actors with 100+ credits don't block the UI
- Includes a small cursor fix on the movie-detail title

## Changes
- `src/lib/tmdb.ts` — `getPerson`, `getPersonMovieCredits`
- `src/app/api/person/[id]/{route,credits/route}.ts` — new API routes, same pattern as `/api/movies/[id]`
- `src/app/person/[id]/page.tsx` — new page: header (avatar/name/department/bio) + filmography grid reusing `MoviesGrid`
- `components/Cast.jsx` — passes `actor.id` through to `Person`
- `components/Person.jsx` — avatar wrapped in `<Link href="/person/${id}">`; click-to-copy preserved on the name/character labels

## Notes
- Credits are de-duplicated by movie ID (TMDb sometimes lists an actor in multiple roles per film)
- `getPersonMovieCredits` returns the whole filmography in one TMDb call (no pagination), so the "infinite scroll" here is render-progressive, not network-paginated

## Test plan
- [ ] Open a movie detail, click an actor's photo → lands on `/person/[id]`
- [ ] Header shows avatar, name, department, bio
- [ ] Filmography is sorted newest first; movies without a release_date appear at the end
- [ ] Scrolling near the bottom loads the next batch of 20
- [ ] "no more results" appears at the end of the list
- [ ] Clicking the actor's name (text below avatar) still copies it to clipboard
- [ ] Close (X) button returns to previous page

🤖 Generated with [Claude Code](https://claude.com/claude-code)